### PR TITLE
Expand algorithm implementations and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
 # 50Algorithms
+
+This repository provides Python implementations of selected algorithms inspired by *50 Algorithms Every Programmer Should Know*. Each implementation includes a brief explanation and complexity analysis.
+
+## Running the examples
+
+Execute:
+
+```
+python run_examples.py
+```
+
+to run the sample implementations and see output for the algorithms that are currently implemented.
+
+## Implemented algorithms and complexities
+
+| # | Algorithm       | Description                                   | Time complexity | Space complexity |
+| - | --------------- | --------------------------------------------- | --------------- | ---------------- |
+| 1 | Binary Search   | Locate an item in a sorted list via bisection | O(log n)        | O(1)             |
+| 2 | Merge Sort      | Divide-and-conquer stable sorting             | O(n log n)      | O(n)             |
+| 3 | Quick Sort      | Partition-based sorting around a pivot        | O(n log n)*     | O(log n)         |
+| 4 | Insertion Sort  | Insert each item into sorted prefix          | O(n^2)          | O(1)             |
+| 5 | Selection Sort  | Repeatedly select minimum element            | O(n^2)          | O(1)             |
+| 6 | Bubble Sort     | Swap adjacent out-of-order items             | O(n^2)          | O(1)             |
+| 7 | Counting Sort   | Count occurrences of small integer keys      | O(n + k)        | O(k)             |
+| 8 | Radix Sort      | Digit-wise sorting using counting sort       | O(d*(n + b))    | O(n + b)         |
+| 9 | Bucket Sort     | Distribute and sort into buckets             | O(n + k)        | O(n)             |
+| 10 | Heap Sort       | Sort via binary heap operations              | O(n log n)      | O(n)             |
+| 11 | Shell Sort      | Gap-based insertion sort                     | ~O(n^{3/2})     | O(1)             |
+| 12 | Quickselect     | Select k-th element using partitioning       | O(n) avg        | O(1)             |
+| 13 | Breadth-First Search | Layer-by-layer graph traversal          | O(V + E)        | O(V)             |
+| 14 | Depth-First Search  | Recursive graph traversal                | O(V + E)        | O(V)             |
+| 15 | Dijkstra            | Shortest paths in weighted graphs        | O(E log V)      | O(V)             |
+| 16 | Bellman-Ford        | Shortest paths with negative weights     | O(V * E)        | O(V)             |
+| 17 | Floyd-Warshall      | All-pairs shortest paths                 | O(V^3)          | O(V^2)           |
+| 18 | Topological Sort    | DAG vertex ordering                      | O(V + E)        | O(V)             |
+| 19 | Kruskal             | Minimum spanning tree via edge sorting   | O(E log E)      | O(V)             |
+| 20 | Prim                | Minimum spanning tree via greedy growth  | O(E log V)      | O(V)             |
+| 21 | Union-Find          | Disjoint-set union structure             | ~O(α(n))        | O(n)             |
+| 22 | Euclid GCD          | Greatest common divisor                  | O(log n)        | O(1)             |
+| 23 | Sieve of Eratosthenes | Generate primes up to n               | O(n log log n)  | O(n)             |
+| 24 | Exponentiation by Squaring | Fast power calculation           | O(log n)        | O(1)             |
+| 25 | KMP Search          | Linear-time substring search             | O(n + m)        | O(m)             |
+| 26 | Rabin-Karp          | Rolling-hash substring search            | O(n + m) avg    | O(1)             |
+
+\* Worst case O(n^2)
+
+## Algorithm index
+
+1. `binary_search_1` – Locate an item in a sorted list by halving the search interval. Run: `python run_examples.py`
+2. `merge_sort_2` – Stable divide-and-conquer sorting by merging sorted halves. Run: `python run_examples.py`
+3. `quick_sort_3` – Partition-based sorting around a pivot. Run: `python run_examples.py`
+4. `bfs_4` – Layer-by-layer graph traversal using a queue. Run: `python run_examples.py`
+5. `dfs_5` – Depth-first graph traversal using recursion or a stack. Run: `python run_examples.py`
+6. `dijkstra_6` – Shortest paths in weighted graphs with non-negative edges. Run: `python run_examples.py`
+7. `bellman_ford_7` – Shortest paths allowing negative edges. Run: `python run_examples.py`
+8. `floyd_warshall_8` – All-pairs shortest paths via dynamic programming. Run: `python run_examples.py`
+9. `topological_sort_9` – Linear ordering of DAG vertices. Run: `python run_examples.py`
+10. `kruskal_10` – Minimum spanning tree via edge sorting. Run: `python run_examples.py`
+11. `prim_11` – Minimum spanning tree using greedy expansion. Run: `python run_examples.py`
+12. `a_star_12` – Heuristic pathfinding. *Implementation pending*
+13. `binary_heap_13` – Priority queue based on a heap. *Implementation pending*
+14. `counting_sort_14` – Linear-time sorting for small integer keys. Run: `python run_examples.py`
+15. `radix_sort_15` – Digit-by-digit sorting. Run: `python run_examples.py`
+16. `bucket_sort_16` – Distribution sorting into buckets. Run: `python run_examples.py`
+17. `insertion_sort_17` – In-place iterative insertion. Run: `python run_examples.py`
+18. `selection_sort_18` – In-place selection of minimum elements. Run: `python run_examples.py`
+19. `bubble_sort_19` – Adjacent swaps until sorted. Run: `python run_examples.py`
+20. `heap_sort_20` – Sorting using a binary heap. Run: `python run_examples.py`
+21. `shell_sort_21` – Gap-based generalization of insertion sort. Run: `python run_examples.py`
+22. `inorder_traversal_22` – In-order binary tree traversal. *Implementation pending*
+23. `preorder_traversal_23` – Pre-order binary tree traversal. *Implementation pending*
+24. `postorder_traversal_24` – Post-order binary tree traversal. *Implementation pending*
+25. `kmp_search_25` – Linear-time substring search. Run: `python run_examples.py`
+26. `rabin_karp_26` – Rolling hash based substring search. Run: `python run_examples.py`
+27. `boyer_moore_27` – Efficient substring search using heuristics. *Implementation pending*
+28. `longest_common_subsequence_28` – DP for longest common subsequence. *Implementation pending*
+29. `longest_increasing_subsequence_29` – Find longest increasing subsequence. *Implementation pending*
+30. `edit_distance_30` – Levenshtein distance between strings. *Implementation pending*
+31. `knapsack_dp_31` – 0/1 knapsack via dynamic programming. *Implementation pending*
+32. `coin_change_dp_32` – Fewest coins for an amount. *Implementation pending*
+33. `strassen_matrix_multiply_33` – Fast matrix multiplication. *Implementation pending*
+34. `union_find_34` – Disjoint set data structure. Run: `python run_examples.py`
+35. `quickselect_35` – Selection algorithm to find k-th element. Run: `python run_examples.py`
+36. `huffman_coding_36` – Optimal prefix codes. *Implementation pending*
+37. `sieve_of_eratosthenes_37` – Generate prime numbers efficiently. Run: `python run_examples.py`
+38. `euclid_gcd_38` – Compute greatest common divisor. Run: `python run_examples.py`
+39. `fast_fourier_transform_39` – Efficient discrete Fourier transform. *Implementation pending*
+40. `exponentiation_by_squaring_40` – Fast power calculation. Run: `python run_examples.py`
+41. `trie_41` – Prefix tree for fast lookups. *Implementation pending*
+42. `pagerank_42` – Rank web pages via link analysis. *Implementation pending*
+43. `minimax_43` – Game tree search for optimal play. *Implementation pending*
+44. `monte_carlo_44` – Probabilistic simulation algorithm. *Implementation pending*
+45. `gradient_descent_45` – Optimization via gradient steps. *Implementation pending*
+46. `naive_bayes_46` – Probabilistic classifier. *Implementation pending*
+47. `k_means_47` – Unsupervised clustering. *Implementation pending*
+48. `principal_component_analysis_48` – Dimensionality reduction. *Implementation pending*
+49. `apriori_49` – Frequent itemset mining. *Implementation pending*
+50. `simulated_annealing_50` – Stochastic optimization technique. *Implementation pending*
+

--- a/algorithms/__init__.py
+++ b/algorithms/__init__.py
@@ -1,0 +1,57 @@
+"""Collection of classic algorithms with descriptive docstrings."""
+
+from .binary_search import binary_search
+from .merge_sort import merge_sort
+from .quick_sort import quick_sort
+from .insertion_sort import insertion_sort
+from .selection_sort import selection_sort
+from .bubble_sort import bubble_sort
+from .counting_sort import counting_sort
+from .radix_sort import radix_sort
+from .bucket_sort import bucket_sort
+from .heap_sort import heap_sort
+from .shell_sort import shell_sort
+from .quickselect import quickselect
+from .bfs import bfs
+from .dfs import dfs
+from .dijkstra import dijkstra
+from .bellman_ford import bellman_ford
+from .floyd_warshall import floyd_warshall
+from .topological_sort import topological_sort
+from .union_find import UnionFind
+from .kruskal import kruskal
+from .prim import prim
+from .euclid_gcd import euclid_gcd
+from .sieve_of_eratosthenes import sieve_of_eratosthenes
+from .exponentiation_by_squaring import power
+from .kmp_search import kmp_search
+from .rabin_karp import rabin_karp
+
+__all__ = [
+    "binary_search",
+    "merge_sort",
+    "quick_sort",
+    "insertion_sort",
+    "selection_sort",
+    "bubble_sort",
+    "counting_sort",
+    "radix_sort",
+    "bucket_sort",
+    "heap_sort",
+    "shell_sort",
+    "quickselect",
+    "bfs",
+    "dfs",
+    "dijkstra",
+    "bellman_ford",
+    "floyd_warshall",
+    "topological_sort",
+    "UnionFind",
+    "kruskal",
+    "prim",
+    "euclid_gcd",
+    "sieve_of_eratosthenes",
+    "power",
+    "kmp_search",
+    "rabin_karp",
+]

--- a/algorithms/bellman_ford.py
+++ b/algorithms/bellman_ford.py
@@ -1,0 +1,43 @@
+"""
+Bellman-Ford shortest path algorithm.
+
+This implementation relaxes all edges |V|-1 times, allowing detection of
+shortest paths even with negative edge weights.
+
+Time Complexity: O(V * E)
+Space Complexity: O(V)
+"""
+from typing import Dict, List, Tuple, Hashable
+
+
+def bellman_ford(graph: Dict[Hashable, List[Tuple[Hashable, float]]], start: Hashable) -> Dict[Hashable, float]:
+    """Return the shortest distance from *start* to every other node.
+
+    Raises
+    ------
+    ValueError
+        If a negative-weight cycle is detected.
+    """
+    # Initialize distances
+    distances: Dict[Hashable, float] = {node: float("inf") for node in graph}
+    distances[start] = 0.0
+
+    # Relax edges repeatedly
+    nodes = list(graph.keys())
+    for _ in range(len(nodes) - 1):
+        updated = False
+        for u in nodes:
+            for v, w in graph.get(u, []):
+                if distances[u] + w < distances[v]:
+                    distances[v] = distances[u] + w
+                    updated = True
+        if not updated:
+            break
+
+    # Check for negative cycles
+    for u in nodes:
+        for v, w in graph.get(u, []):
+            if distances[u] + w < distances[v]:
+                raise ValueError("Graph contains a negative-weight cycle")
+
+    return distances

--- a/algorithms/bfs.py
+++ b/algorithms/bfs.py
@@ -1,0 +1,25 @@
+"""
+Breadth-first search (BFS).
+
+BFS explores a graph level by level starting from a source node using a queue.
+It visits all nodes at the current depth before moving to the next level.
+
+Time Complexity: O(V + E)
+Space Complexity: O(V)
+"""
+from collections import deque
+from typing import Dict, List, Hashable
+
+def bfs(graph: Dict[Hashable, List[Hashable]], start: Hashable) -> List[Hashable]:
+    """Return list of nodes visited in BFS order starting from *start*."""
+    visited = set([start])
+    queue = deque([start])
+    order: List[Hashable] = []
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for neighbor in graph.get(node, []):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append(neighbor)
+    return order

--- a/algorithms/binary_search.py
+++ b/algorithms/binary_search.py
@@ -1,0 +1,33 @@
+"""
+Binary search algorithm.
+
+This function searches for a target value within a sorted list by repeatedly
+splitting the search interval in half. At each step it compares the target with
+the middle element and continues in the half where the target may reside.
+
+Time Complexity: O(log n)
+Space Complexity: O(1)
+"""
+
+from typing import Sequence, Any, Optional
+
+def binary_search(data: Sequence[Any], target: Any) -> Optional[int]:
+    """Return the index of *target* in the sorted sequence *data* or ``None``.
+
+    Parameters
+    ----------
+    data: Sequence[Any]
+        A sorted sequence to search through.
+    target: Any
+        The value to locate.
+    """
+    left, right = 0, len(data) - 1
+    while left <= right:
+        mid = (left + right) // 2
+        if data[mid] == target:
+            return mid
+        if data[mid] < target:
+            left = mid + 1
+        else:
+            right = mid - 1
+    return None

--- a/algorithms/bubble_sort.py
+++ b/algorithms/bubble_sort.py
@@ -1,0 +1,17 @@
+"""Bubble sort algorithm.
+
+This simple comparison sort repeatedly steps through the list, swapping adjacent
+items that are out of order.
+Time Complexity: O(n^2)
+Space Complexity: O(1)
+"""
+
+def bubble_sort(arr):
+    """Return a new list containing the sorted elements of *arr* using bubble sort."""
+    a = arr[:]
+    n = len(a)
+    for i in range(n):
+        for j in range(0, n - i - 1):
+            if a[j] > a[j + 1]:
+                a[j], a[j + 1] = a[j + 1], a[j]
+    return a

--- a/algorithms/bucket_sort.py
+++ b/algorithms/bucket_sort.py
@@ -1,0 +1,17 @@
+"""Bucket sort algorithm for numbers in [0, 1).
+
+Distributes input numbers into a fixed number of buckets, sorts each bucket, and
+concatenates the results.
+Time Complexity: O(n + k) average
+Space Complexity: O(n)
+"""
+
+def bucket_sort(arr, bucket_count=10):
+    """Return a new list containing the sorted elements of *arr* using bucket sort."""
+    buckets = [[] for _ in range(bucket_count)]
+    for num in arr:
+        index = min(bucket_count - 1, int(num * bucket_count))
+        buckets[index].append(num)
+    for bucket in buckets:
+        bucket.sort()
+    return [num for bucket in buckets for num in bucket]

--- a/algorithms/counting_sort.py
+++ b/algorithms/counting_sort.py
@@ -1,0 +1,20 @@
+"""Counting sort algorithm for non-negative integers.
+
+Counts the occurrences of each value and reconstructs the sorted list.
+Time Complexity: O(n + k) where k is the range of the input.
+Space Complexity: O(k)
+"""
+
+def counting_sort(arr, max_val=None):
+    """Return a new list containing the sorted elements of *arr* using counting sort."""
+    if not arr:
+        return []
+    if max_val is None:
+        max_val = max(arr)
+    count = [0] * (max_val + 1)
+    for num in arr:
+        count[num] += 1
+    output = []
+    for num, c in enumerate(count):
+        output.extend([num] * c)
+    return output

--- a/algorithms/dfs.py
+++ b/algorithms/dfs.py
@@ -1,0 +1,23 @@
+"""
+Depth-first search (DFS).
+
+DFS explores as far as possible along each branch before backtracking. It can be
+implemented recursively or using a stack. This implementation uses recursion.
+
+Time Complexity: O(V + E)
+Space Complexity: O(V) due to recursion stack
+"""
+from typing import Dict, List, Hashable
+
+def dfs(graph: Dict[Hashable, List[Hashable]], start: Hashable) -> List[Hashable]:
+    """Return list of nodes visited in DFS order starting from *start*."""
+    visited = set()
+    order: List[Hashable] = []
+    def _visit(node: Hashable) -> None:
+        visited.add(node)
+        order.append(node)
+        for neighbor in graph.get(node, []):
+            if neighbor not in visited:
+                _visit(neighbor)
+    _visit(start)
+    return order

--- a/algorithms/dijkstra.py
+++ b/algorithms/dijkstra.py
@@ -1,0 +1,26 @@
+"""
+Dijkstra's shortest path algorithm.
+
+This algorithm computes the shortest paths from a starting node to all other
+nodes in a weighted graph with non-negative edge weights.
+
+Time Complexity: O(E log V) using a priority queue
+Space Complexity: O(V)
+"""
+import heapq
+from typing import Dict, List, Tuple, Hashable
+
+def dijkstra(graph: Dict[Hashable, List[Tuple[Hashable, float]]], start: Hashable) -> Dict[Hashable, float]:
+    """Return a mapping of nodes to their minimum distance from *start*."""
+    distances: Dict[Hashable, float] = {start: 0.0}
+    heap: List[Tuple[float, Hashable]] = [(0.0, start)]
+    while heap:
+        dist, node = heapq.heappop(heap)
+        if dist > distances.get(node, float('inf')):
+            continue
+        for neighbor, weight in graph.get(node, []):
+            new_dist = dist + weight
+            if new_dist < distances.get(neighbor, float('inf')):
+                distances[neighbor] = new_dist
+                heapq.heappush(heap, (new_dist, neighbor))
+    return distances

--- a/algorithms/euclid_gcd.py
+++ b/algorithms/euclid_gcd.py
@@ -1,0 +1,12 @@
+"""Euclid's algorithm for greatest common divisor (GCD).
+
+Repeatedly replaces the larger number with the remainder until zero is reached.
+Time Complexity: O(log min(a, b))
+Space Complexity: O(1)
+"""
+
+def euclid_gcd(a, b):
+    """Return the greatest common divisor of *a* and *b*."""
+    while b:
+        a, b = b, a % b
+    return a

--- a/algorithms/exponentiation_by_squaring.py
+++ b/algorithms/exponentiation_by_squaring.py
@@ -1,0 +1,16 @@
+"""Exponentiation by squaring for fast power calculation.
+
+Repeatedly squares the base and multiplies into the result when the exponent bit is 1.
+Time Complexity: O(log n)
+Space Complexity: O(1)
+"""
+
+def power(base, exponent):
+    """Return *base* raised to *exponent* using exponentiation by squaring."""
+    result = 1
+    while exponent > 0:
+        if exponent % 2 == 1:
+            result *= base
+        base *= base
+        exponent //= 2
+    return result

--- a/algorithms/floyd_warshall.py
+++ b/algorithms/floyd_warshall.py
@@ -1,0 +1,29 @@
+"""
+Floyd-Warshall all-pairs shortest path algorithm.
+
+Uses dynamic programming to iteratively improve the shortest distance between
+all pairs of vertices by considering each vertex as an intermediate point.
+
+Time Complexity: O(V^3)
+Space Complexity: O(V^2)
+"""
+from typing import Dict, Hashable
+
+
+def floyd_warshall(graph: Dict[Hashable, Dict[Hashable, float]]) -> Dict[Hashable, Dict[Hashable, float]]:
+    """Return a distance matrix mapping node pairs to their shortest distance."""
+    nodes = list(graph.keys())
+    dist: Dict[Hashable, Dict[Hashable, float]] = {
+        u: {v: float("inf") for v in nodes} for u in nodes
+    }
+    for u in nodes:
+        dist[u][u] = 0.0
+        for v, w in graph.get(u, {}).items():
+            dist[u][v] = w
+
+    for k in nodes:
+        for i in nodes:
+            for j in nodes:
+                if dist[i][k] + dist[k][j] < dist[i][j]:
+                    dist[i][j] = dist[i][k] + dist[k][j]
+    return dist

--- a/algorithms/heap_sort.py
+++ b/algorithms/heap_sort.py
@@ -1,0 +1,14 @@
+"""Heap sort algorithm using Python's heapq module.
+
+Builds a heap from the input and repeatedly extracts the smallest element.
+Time Complexity: O(n log n)
+Space Complexity: O(n)
+"""
+
+import heapq
+
+def heap_sort(arr):
+    """Return a new list containing the sorted elements of *arr* using heap sort."""
+    h = arr[:]
+    heapq.heapify(h)
+    return [heapq.heappop(h) for _ in range(len(h))]

--- a/algorithms/insertion_sort.py
+++ b/algorithms/insertion_sort.py
@@ -1,0 +1,19 @@
+"""Insertion sort algorithm.
+
+This in-place, comparison-based algorithm builds the sorted array one item at a time
+by inserting each element into its correct position within the already sorted portion.
+Time Complexity: O(n^2)
+Space Complexity: O(1)
+"""
+
+def insertion_sort(arr):
+    """Return a new list containing the sorted elements of *arr* using insertion sort."""
+    a = arr[:]
+    for i in range(1, len(a)):
+        key = a[i]
+        j = i - 1
+        while j >= 0 and a[j] > key:
+            a[j + 1] = a[j]
+            j -= 1
+        a[j + 1] = key
+    return a

--- a/algorithms/kmp_search.py
+++ b/algorithms/kmp_search.py
@@ -1,0 +1,30 @@
+"""Knuth-Morris-Pratt substring search algorithm.
+
+Uses a prefix table to avoid redundant comparisons.
+Time Complexity: O(n + m)
+Space Complexity: O(m)
+"""
+
+def kmp_search(text, pattern):
+    """Return starting indices where *pattern* is found within *text*."""
+    if pattern == "":
+        return list(range(len(text) + 1))
+    lps = [0] * len(pattern)
+    j = 0
+    for i in range(1, len(pattern)):
+        while j > 0 and pattern[i] != pattern[j]:
+            j = lps[j - 1]
+        if pattern[i] == pattern[j]:
+            j += 1
+            lps[i] = j
+    res = []
+    j = 0
+    for i in range(len(text)):
+        while j > 0 and text[i] != pattern[j]:
+            j = lps[j - 1]
+        if text[i] == pattern[j]:
+            j += 1
+            if j == len(pattern):
+                res.append(i - j + 1)
+                j = lps[j - 1]
+    return res

--- a/algorithms/kruskal.py
+++ b/algorithms/kruskal.py
@@ -1,0 +1,21 @@
+"""Kruskal's algorithm for minimum spanning tree.
+
+Sorts edges by weight and adds them if they don't form a cycle, using Union-Find.
+Time Complexity: O(E log E)
+Space Complexity: O(V)
+"""
+
+from .union_find import UnionFind
+
+def kruskal(vertices, edges):
+    """Return the edges in the minimum spanning tree using Kruskal's algorithm.
+
+    *vertices* is an iterable of vertices; *edges* is an iterable of (u, v, w).
+    """
+    uf = UnionFind(vertices)
+    mst = []
+    for u, v, w in sorted(edges, key=lambda x: x[2]):
+        if uf.find(u) != uf.find(v):
+            uf.union(u, v)
+            mst.append((u, v, w))
+    return mst

--- a/algorithms/merge_sort.py
+++ b/algorithms/merge_sort.py
@@ -1,0 +1,33 @@
+"""
+Merge sort algorithm.
+
+Merge sort is a divide-and-conquer algorithm that splits the input list into
+halves, recursively sorts each half, and then merges the sorted halves.
+
+Time Complexity: O(n log n)
+Space Complexity: O(n)
+"""
+from typing import List, Any
+
+def merge_sort(data: List[Any]) -> List[Any]:
+    """Return a new list containing all items from *data* in sorted order."""
+    if len(data) <= 1:
+        return data[:]
+    mid = len(data) // 2
+    left = merge_sort(data[:mid])
+    right = merge_sort(data[mid:])
+    return _merge(left, right)
+
+def _merge(left: List[Any], right: List[Any]) -> List[Any]:
+    result = []
+    i = j = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+    result.extend(left[i:])
+    result.extend(right[j:])
+    return result

--- a/algorithms/prim.py
+++ b/algorithms/prim.py
@@ -1,0 +1,28 @@
+"""Prim's algorithm for minimum spanning tree.
+
+Grows the MST by attaching the nearest vertex using a priority queue.
+Time Complexity: O(E log V)
+Space Complexity: O(V)
+"""
+
+import heapq
+
+def prim(graph, start):
+    """Return the edges in the minimum spanning tree of *graph* starting from *start*.
+
+    *graph* maps vertices to iterables of (neighbor, weight).
+    """
+    visited = {start}
+    edges = []
+    for v, w in graph[start]:
+        heapq.heappush(edges, (w, start, v))
+    mst = []
+    while edges and len(visited) < len(graph):
+        w, u, v = heapq.heappop(edges)
+        if v not in visited:
+            visited.add(v)
+            mst.append((u, v, w))
+            for nv, nw in graph[v]:
+                if nv not in visited:
+                    heapq.heappush(edges, (nw, v, nv))
+    return mst

--- a/algorithms/quick_sort.py
+++ b/algorithms/quick_sort.py
@@ -1,0 +1,21 @@
+"""
+Quick sort algorithm.
+
+Quick sort selects a pivot element and partitions the remaining elements into
+those less than the pivot and those greater. It recursively sorts the
+partitions and concatenates the results.
+
+Average Time Complexity: O(n log n)
+Worst-case Time Complexity: O(n^2)
+Space Complexity: O(log n) for recursion
+"""
+from typing import List, Any
+
+def quick_sort(data: List[Any]) -> List[Any]:
+    if len(data) <= 1:
+        return data[:]
+    pivot = data[len(data) // 2]
+    less = [x for x in data if x < pivot]
+    equal = [x for x in data if x == pivot]
+    greater = [x for x in data if x > pivot]
+    return quick_sort(less) + equal + quick_sort(greater)

--- a/algorithms/quickselect.py
+++ b/algorithms/quickselect.py
@@ -1,0 +1,23 @@
+"""Quickselect algorithm to find the k-th smallest element.
+
+Uses the same partitioning idea as quicksort but only recurses into one partition.
+Time Complexity: O(n) average, O(n^2) worst
+Space Complexity: O(1) average (ignoring recursion stack)
+"""
+
+import random
+
+def quickselect(arr, k):
+    """Return the k-th smallest element of *arr* (0-indexed) using quickselect."""
+    if len(arr) == 1:
+        return arr[0]
+    pivot = random.choice(arr)
+    lows = [x for x in arr if x < pivot]
+    highs = [x for x in arr if x > pivot]
+    pivots = [x for x in arr if x == pivot]
+    if k < len(lows):
+        return quickselect(lows, k)
+    elif k < len(lows) + len(pivots):
+        return pivot
+    else:
+        return quickselect(highs, k - len(lows) - len(pivots))

--- a/algorithms/rabin_karp.py
+++ b/algorithms/rabin_karp.py
@@ -1,0 +1,25 @@
+"""Rabin-Karp substring search algorithm using rolling hash.
+
+Computes hash values to quickly skip non-matching segments.
+Time Complexity: O(n + m) average
+Space Complexity: O(1)
+"""
+
+def rabin_karp(text, pattern, base=256, mod=101):
+    """Return starting indices where *pattern* occurs in *text* using Rabin-Karp."""
+    n, m = len(text), len(pattern)
+    if m == 0 or m > n:
+        return []
+    h = pow(base, m - 1, mod)
+    p = t = 0
+    for i in range(m):
+        p = (p * base + ord(pattern[i])) % mod
+        t = (t * base + ord(text[i])) % mod
+    res = []
+    for i in range(n - m + 1):
+        if p == t and text[i : i + m] == pattern:
+            res.append(i)
+        if i < n - m:
+            t = (t - ord(text[i]) * h) * base + ord(text[i + m])
+            t %= mod
+    return res

--- a/algorithms/radix_sort.py
+++ b/algorithms/radix_sort.py
@@ -1,0 +1,29 @@
+"""Radix sort algorithm for non-negative integers (base 10, LSD variant).
+
+Sorts numbers digit by digit using counting sort as a subroutine.
+Time Complexity: O(d * (n + b)) where d is number of digits and b is base.
+Space Complexity: O(n + b)
+"""
+
+def radix_sort(arr):
+    """Return a new list containing the sorted elements of *arr* using radix sort."""
+    if not arr:
+        return []
+    result = arr[:]
+    max_val = max(result)
+    exp = 1
+    while max_val // exp > 0:
+        count = [0] * 10
+        output = [0] * len(result)
+        for num in result:
+            index = (num // exp) % 10
+            count[index] += 1
+        for i in range(1, 10):
+            count[i] += count[i - 1]
+        for num in reversed(result):
+            index = (num // exp) % 10
+            count[index] -= 1
+            output[count[index]] = num
+        result = output
+        exp *= 10
+    return result

--- a/algorithms/selection_sort.py
+++ b/algorithms/selection_sort.py
@@ -1,0 +1,19 @@
+"""Selection sort algorithm.
+
+The algorithm repeatedly selects the smallest remaining element and swaps it into its
+correct position.
+Time Complexity: O(n^2)
+Space Complexity: O(1)
+"""
+
+def selection_sort(arr):
+    """Return a new list containing the sorted elements of *arr* using selection sort."""
+    a = arr[:]
+    n = len(a)
+    for i in range(n):
+        min_idx = i
+        for j in range(i + 1, n):
+            if a[j] < a[min_idx]:
+                min_idx = j
+        a[i], a[min_idx] = a[min_idx], a[i]
+    return a

--- a/algorithms/shell_sort.py
+++ b/algorithms/shell_sort.py
@@ -1,0 +1,22 @@
+"""Shell sort algorithm.
+
+Generalization of insertion sort that allows the exchange of items far apart by
+using decreasing gap sequences.
+Time Complexity: depends on gap sequence; O(n^(3/2)) typical
+Space Complexity: O(1)
+"""
+
+def shell_sort(arr):
+    """Return a new list containing the sorted elements of *arr* using shell sort."""
+    a = arr[:]
+    gap = len(a) // 2
+    while gap > 0:
+        for i in range(gap, len(a)):
+            temp = a[i]
+            j = i
+            while j >= gap and a[j - gap] > temp:
+                a[j] = a[j - gap]
+                j -= gap
+            a[j] = temp
+        gap //= 2
+    return a

--- a/algorithms/sieve_of_eratosthenes.py
+++ b/algorithms/sieve_of_eratosthenes.py
@@ -1,0 +1,17 @@
+"""Sieve of Eratosthenes for generating primes up to n.
+
+Marks multiples of each prime starting from 2.
+Time Complexity: O(n log log n)
+Space Complexity: O(n)
+"""
+
+def sieve_of_eratosthenes(n):
+    """Return a list of all prime numbers less than or equal to *n*."""
+    if n < 2:
+        return []
+    sieve = [True] * (n + 1)
+    sieve[0:2] = [False, False]
+    for i in range(2, int(n ** 0.5) + 1):
+        if sieve[i]:
+            sieve[i * i : n + 1 : i] = [False] * len(range(i * i, n + 1, i))
+    return [i for i, prime in enumerate(sieve) if prime]

--- a/algorithms/topological_sort.py
+++ b/algorithms/topological_sort.py
@@ -1,0 +1,34 @@
+"""
+Topological sort for directed acyclic graphs (DAGs).
+
+This implementation uses Kahn's algorithm to repeatedly remove nodes with zero
+in-degree, producing a linear ordering where each node appears before all nodes
+it points to.
+
+Time Complexity: O(V + E)
+Space Complexity: O(V)
+"""
+from collections import deque
+from typing import Dict, List, Hashable
+
+
+def topological_sort(graph: Dict[Hashable, List[Hashable]]) -> List[Hashable]:
+    """Return a list of nodes in topologically sorted order."""
+    in_degree: Dict[Hashable, int] = {node: 0 for node in graph}
+    for neighbors in graph.values():
+        for v in neighbors:
+            in_degree[v] = in_degree.get(v, 0) + 1
+
+    queue = deque([node for node, deg in in_degree.items() if deg == 0])
+    order: List[Hashable] = []
+    while queue:
+        u = queue.popleft()
+        order.append(u)
+        for v in graph.get(u, []):
+            in_degree[v] -= 1
+            if in_degree[v] == 0:
+                queue.append(v)
+
+    if len(order) != len(in_degree):
+        raise ValueError("Graph has at least one cycle")
+    return order

--- a/algorithms/union_find.py
+++ b/algorithms/union_find.py
@@ -1,0 +1,29 @@
+"""Disjoint-set union (Union-Find) data structure.
+
+Supports efficient union and find operations using path compression and union by rank.
+Time Complexity: effectively O(α(n)) per operation.
+Space Complexity: O(n)
+"""
+
+class UnionFind:
+    """Union-Find structure managing disjoint sets."""
+    def __init__(self, elements):
+        self.parent = {x: x for x in elements}
+        self.rank = {x: 0 for x in elements}
+
+    def find(self, x):
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+        return self.parent[x]
+
+    def union(self, a, b):
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return
+        if self.rank[ra] < self.rank[rb]:
+            self.parent[ra] = rb
+        elif self.rank[ra] > self.rank[rb]:
+            self.parent[rb] = ra
+        else:
+            self.parent[rb] = ra
+            self.rank[ra] += 1

--- a/run_examples.py
+++ b/run_examples.py
@@ -1,0 +1,118 @@
+"""Run sample executions of the algorithms and print the results."""
+from algorithms import (
+    binary_search,
+    merge_sort,
+    quick_sort,
+    insertion_sort,
+    selection_sort,
+    bubble_sort,
+    counting_sort,
+    radix_sort,
+    bucket_sort,
+    heap_sort,
+    shell_sort,
+    quickselect,
+    bfs,
+    dfs,
+    dijkstra,
+    bellman_ford,
+    floyd_warshall,
+    topological_sort,
+    kruskal,
+    prim,
+    euclid_gcd,
+    sieve_of_eratosthenes,
+    power,
+    kmp_search,
+    rabin_karp,
+)
+
+# Sorting examples
+unsorted_list = [5, 3, 8, 4, 2]
+print("merge_sort:", merge_sort(unsorted_list))
+print("quick_sort:", quick_sort(unsorted_list))
+print("insertion_sort:", insertion_sort(unsorted_list))
+print("selection_sort:", selection_sort(unsorted_list))
+print("bubble_sort:", bubble_sort(unsorted_list))
+print("heap_sort:", heap_sort(unsorted_list))
+print("shell_sort:", shell_sort(unsorted_list))
+
+int_list = [5, 3, 0, 2, 3, 1]
+print("counting_sort:", counting_sort(int_list))
+print("radix_sort:", radix_sort([170, 45, 75, 90, 802, 24, 2, 66]))
+print("bucket_sort:", bucket_sort([0.78, 0.17, 0.39, 0.26, 0.72, 0.94, 0.21, 0.12, 0.23, 0.68]))
+
+print("quickselect k=2:", quickselect(unsorted_list, 2))
+
+# Binary search example
+sorted_list = [1, 3, 4, 5, 7, 8]
+print("binary_search for 5:", binary_search(sorted_list, 5))
+print("binary_search for 6:", binary_search(sorted_list, 6))
+
+# Graph examples
+graph = {
+    'A': ['B', 'C'],
+    'B': ['D', 'E'],
+    'C': ['F'],
+    'D': [],
+    'E': ['F'],
+    'F': []
+}
+print("bfs:", bfs(graph, 'A'))
+print("dfs:", dfs(graph, 'A'))
+
+weighted_graph = {
+    'A': [('B', 1), ('C', 4)],
+    'B': [('C', 2), ('D', 5)],
+    'C': [('D', 1)],
+    'D': []
+}
+print("dijkstra:", dijkstra(weighted_graph, 'A'))
+
+# Bellman-Ford example
+bf_graph = {
+    'A': [('B', 4), ('C', 2)],
+    'B': [('C', -1), ('D', 2)],
+    'C': [('D', 3)],
+    'D': []
+}
+print("bellman_ford:", bellman_ford(bf_graph, 'A'))
+
+# Floyd-Warshall example
+fw_graph = {
+    'A': {'B': 5, 'C': 9, 'D': 1},
+    'B': {'C': 2},
+    'C': {'D': 7},
+    'D': {'B': 2, 'C': 6}
+}
+print("floyd_warshall:", floyd_warshall(fw_graph))
+
+# Topological sort example
+dag = {
+    'A': ['B', 'C'],
+    'B': ['D'],
+    'C': ['D'],
+    'D': []
+}
+print("topological_sort:", topological_sort(dag))
+
+# Minimum spanning tree examples
+mst_vertices = ['A', 'B', 'C', 'D']
+mst_edges = [('A', 'B', 1), ('B', 'C', 2), ('A', 'C', 2), ('C', 'D', 1)]
+print("kruskal:", kruskal(mst_vertices, mst_edges))
+prim_graph = {
+    'A': [('B', 1), ('C', 2)],
+    'B': [('C', 2), ('D', 3)],
+    'C': [('D', 1)],
+    'D': []
+}
+print("prim:", prim(prim_graph, 'A'))
+
+# Number theory and string algorithms
+print("euclid_gcd:", euclid_gcd(48, 18))
+print("sieve_of_eratosthenes:", sieve_of_eratosthenes(20))
+print("power 2^10:", power(2, 10))
+text = "ababcabcabababd"
+pattern = "ababd"
+print("kmp_search:", kmp_search(text, pattern))
+print("rabin_karp:", rabin_karp(text, pattern))


### PR DESCRIPTION
## Summary
- add numerous classic algorithms (e.g., insertion sort, kruskal, prim, gcd) with docstrings detailing approach and complexity
- broaden README to record complexities and index entries for the newly implemented algorithms
- extend example runner to showcase new sorts, graph algorithms, and string/number utilities
- add serial number column to the algorithm complexity table for easier reference

## Testing
- `python run_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4b033019083208171abd477a3b8ee